### PR TITLE
Fix render syntax to display Navbar

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,5 +8,5 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </React.StrictMode>,
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- remove stray comma in React render call to allow App and Navbar components to mount

## Testing
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f450542e48325b0b311b7957dd4a8